### PR TITLE
add necessary code to support 4.9.2

### DIFF
--- a/antlr/repositories.bzl
+++ b/antlr/repositories.bzl
@@ -3,13 +3,18 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
 load(":lang.bzl", "C", "CPP", "GO", "JAVA", "OBJC", "PYTHON", "PYTHON2", "PYTHON3", supportedLanguages = "supported")
 
-v4 = [4, "4.7.1", "4.7.2", "4.8"]
+v4 = [4, "4.7.1", "4.7.2", "4.8", "4.9.2"]
 v4_opt = [4, "4.7.1", "4.7.2", "4.7.3", "4.7.4"]
 v3 = [3, "3.5.2"]
 v2 = [2, "2.7.7"]
 
 PACKAGES = {
     "antlr": {
+        "4.9.2": {
+            "url": "https://github.com/antlr/antlr4/archive/4.9.2.tar.gz",
+            "prefix": "antlr4-4.9.2",
+            "sha256": "db170179917ce6fec7bc4ecf72edba36b97c9881e09e03af6ac0c901eba52a8f",
+        },
         "4.8": {
             "url": "https://github.com/antlr/antlr4/archive/4.8.tar.gz",
             "prefix": "antlr4-4.8",
@@ -38,6 +43,10 @@ PACKAGES = {
         },
     },
     "antlr4_runtime": {
+        "4.9.2": {
+            "path": "org/antlr/antlr4-runtime/4.9.2/antlr4-runtime-4.9.2.jar",
+            "sha256": "120053628dd598d43cb7ac6b9ecc72529dfa5a5fd3292d37cf638a81cc0075f6",
+        },
         "4.8": {
             "path": "org/antlr/antlr4-runtime/4.8/antlr4-runtime-4.8.jar",
             "sha256": "2337df5d81e715b39aeea07aac46ad47e4f1f9e9cd7c899f124f425913efdcf8",
@@ -68,6 +77,10 @@ PACKAGES = {
         },
     },
     "antlr4_tool": {
+        "4.9.2": {
+            "path": "org/antlr/antlr4/4.9.2/antlr4-4.9.2.jar",
+            "sha256": "7d66253762da7c8c7ab6ac05da1471aeeb3cb8e92310ecfb08f939306b4c7dae",
+        },
         "4.8": {
             "path": "org/antlr/antlr4/4.8/antlr4-4.8.jar",
             "sha256": "6e4477689371f237d4d8aa40642badbb209d4628ccdd81234d90f829a743bac8",
@@ -179,8 +192,10 @@ def rules_antlr_dependencies(*versionsAndLanguages):
             languages = [JAVA]
 
         for version in sorted(versions, key = _toString):
-            if version == 4 or version == "4.8":
-                _antlr48_dependencies(languages)
+            if version == 4 or version == "4.9.2":
+                _antlr492_dependencies(languages)
+            elif version == "4.8":
+                _antlr48_dependencies(languages
             elif version == "4.7.2":
                 _antlr472_dependencies(languages)
             elif version == "4.7.1":
@@ -216,6 +231,19 @@ def rules_antlr_optimized_dependencies(version):
         fail('Integer version \'{}\' no longer valid. Use semantic version "{}" instead.'.format(version, ".".join(str(version).elems())), attr = "version")
     else:
         fail('Unsupported ANTLR version provided: "{0}". Currently supported are: {1}'.format(version, v4_opt), attr = "version")
+
+def _antlr492_dependencies(languages):
+    _antlr4_dependencies(
+        "4.9.2",
+        languages,
+        {
+            "antlr4_runtime": "4.9.2",
+            "antlr4_tool": "4.9.2",
+            "antlr3_runtime": "3.5.2",
+            "stringtemplate4": "4.3",
+            "javax_json": "1.0.4",
+        },
+    )
 
 def _antlr48_dependencies(languages):
     _antlr4_dependencies(


### PR DESCRIPTION
This is needed as the current graphql java lib uses 4.9.2, as in conflict with 4.8 if we continue to use the old antlr version